### PR TITLE
トランジションの修正

### DIFF
--- a/GamePrograming/Application/Source/Game/Transition.cpp
+++ b/GamePrograming/Application/Source/Game/Transition.cpp
@@ -33,6 +33,7 @@ void Transition::Update()
 	}
 	else {
 		m_animFinished = true;
+		m_uvNum = m_animFrameMax - 1;
 	}
 	
 }

--- a/GamePrograming/Application/Source/Game/Transition.cpp
+++ b/GamePrograming/Application/Source/Game/Transition.cpp
@@ -34,6 +34,9 @@ void Transition::Update()
 	else {
 		m_animFinished = true;
 		m_uvNum = m_animFrameMax - 1;
+
+		m_uv.x = m_texSize.x * (static_cast<int>(m_uvNum) % m_uvNumX);
+		m_uv.y = m_texSize.y * (static_cast<int>(m_uvNum) / m_uvNumX);
 	}
 	
 }


### PR DESCRIPTION
終了するときに最後のフレームで固定されるようにした。
ただ、後ろに描画されているものが見えてしまう問題がありそう。IsAnimFinishedがtrueになったらトランジション以外の描画をやめることで解決しそう。