### PR TITLE
syuusei

### DIFF
--- a/GamePrograming/Application/Source/Game/EnemyCpu.cpp
+++ b/GamePrograming/Application/Source/Game/EnemyCpu.cpp
@@ -130,15 +130,15 @@ void EnemyCpu::Update() {
 		}
 	
 	}
-	else if(m_targetObject)
+	else if (m_targetObject)
 	{//ターゲットになるオブジェクトが存在している場合
 		float vec = m_targetObject->GetPos().x - m_pos.x;
-		stickL.x = vec / abs(vec);
-		if (CTRL.GetKeyboardPress(DIK_A))
-		{
-			int a = 0;
-		}
-		
+		if (vec == 0)
+			stickL.x = m_moveDir;
+		else
+			stickL.x = vec / abs(vec);
+
+
 	}
 	else
 	{//オブジェクトを持っていなく、ターゲットのオブジェクトもない場合


### PR DESCRIPTION
リスポーン直後にCPUが吹っ飛ぶのを修正
多分これで治ってる
リスポーンの足場がターゲットになってvecが0になるからっぽい